### PR TITLE
ci: build Docker image (no push) on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a `pull_request`-triggered CI workflow (`.github/workflows/ci.yaml`) that builds the Docker image from `./docker/Dockerfile` **without pushing** to any registry. This gives early build validation on PRs (including Dependabot bumps) before merge.

## Changes

- New workflow `ci.yaml` running on `pull_request`:
  - Checks out the PR
  - Sets up Docker Buildx
  - Builds via `docker/build-push-action` with `push: false`
  - Uses GitHub Actions cache (`type=gha`) to speed up repeated builds

## Notes

- Requires no registry credentials (no push, no login step).
- The existing `build.yaml` is unchanged — it still builds and pushes on push to `main`.

Closes #238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no application or deployment logic changes; build is read-only with no push.
> 
> **Overview**
> Adds a new GitHub Actions workflow **`.github/workflows/ci.yaml`** that runs on **`pull_request`** and validates the Docker build before merge.
> 
> The job checks out the PR, sets up Buildx, and builds from **`./docker/Dockerfile`** with **`push: false`** (no registry login or credentials). It targets **`linux/amd64`** and uses **GitHub Actions cache** (`type=gha`) to speed up repeat builds. Existing **`build.yaml`** push-to-registry behavior on **`main`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3123e3a49d64c62636bc67c4fe7a9f8959476f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->