### PR TITLE
fix(ui): add overflow scrolling to Sheet and Dialog

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+				"fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
 				className,
 			)}
 			{...props}

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -30,7 +30,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-	"fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+	"fixed z-50 gap-4 overflow-y-auto bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
 	{
 		variants: {
 			side: {


### PR DESCRIPTION
## Problem

The UI suffered from missing overflow scrolling in two places:

- **Account info sheet** — the list of streams could grow taller than the viewport and was clipped at the bottom with no way to scroll to the remaining rows.
- **User credentials dialog** — with multiple tall credential textareas the dialog grew taller than the viewport, pushing lower content (including the dialog **Close** button) off-screen and out of reach.

Both stem from the shared UI primitives lacking overflow handling on their fixed-position containers.

## Fix

- `Sheet`: add `overflow-y-auto` to `sheetVariants` so side sheets scroll when their content exceeds the viewport height.
- `Dialog`: cap height at `max-h-[90vh]` and add `overflow-y-auto` so tall dialogs scroll internally while staying within the viewport.

Because the fixes live on the shared primitives, **all** sheets and dialogs across the app now scroll correctly.

## Verification

- Reproduced against the live demo instance by adding streams (`test4`–`test20`) so the account info list overflows.
- Verified the account info sheet now scrolls (content 1526px in a 583px pane) and the credentials dialog caps at 90vh and scrolls internally with the Close button reachable.
- `bun run lint` passes.
- `bun run build` succeeds.
- Full E2E integration suite passes (5/5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Tailwind-only layout changes on shared UI primitives; no auth, data, or business-logic impact.
> 
> **Overview**
> Tall content in modals and side panels was clipped with no way to reach off-screen controls (e.g. **Close**). This PR updates the shared **`Dialog`** and **`Sheet`** primitives so overflow is handled on the fixed containers.
> 
> **`DialogContent`** now uses **`max-h-[90vh]`** and **`overflow-y-auto`**, so dialogs stay within the viewport and scroll internally when content is tall.
> 
> **`sheetVariants`** gains **`overflow-y-auto`**, so side sheets scroll when their body exceeds the viewport height.
> 
> Because these are base components, every dialog and sheet in the app inherits the behavior without per-screen changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e9b4ad7533ddca8b8570b33afb04f7da98d1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->