### PR TITLE
feat(frontend): one-liner to create a NATS CLI context from user creds

### DIFF
--- a/frontend/src/components/ui/users/user-columns.tsx
+++ b/frontend/src/components/ui/users/user-columns.tsx
@@ -68,6 +68,20 @@ export function getUsersColumns(
 			cell: ({ row }) => {
 				const user = row.original;
 
+				const contextName = `${accountData?.name}-${user.name}`.replace(
+					/[^a-zA-Z0-9._-]/g,
+					"-",
+				);
+				const credsPath = `~/.config/nats/creds/${contextName}.creds`;
+				const setupContextCommand = user?.creds
+					? [
+							`umask 077 && mkdir -p ~/.config/nats/creds && cat > ${credsPath} <<'NATS_CREDS_EOF'`,
+							user.creds.trim(),
+							"NATS_CREDS_EOF",
+							`nats context save "${contextName}" --server "${installationData?.url}" --creds ${credsPath} --select`,
+						].join("\n")
+					: undefined;
+
 				return (
 					<div className="text-right">
 						<Dialog>
@@ -84,6 +98,11 @@ export function getUsersColumns(
 										{accountData?.name}'
 									</DialogDescription>
 								</DialogHeader>
+								<CredentialBox
+									title="Create NATS CLI context (macOS & Linux)"
+									value={setupContextCommand}
+									description="Copy & paste this one-liner into your terminal. It stores the credentials and creates a selected NATS CLI context, so you can immediately run commands like 'nats stream ls'."
+								/>
 								<CredentialBox
 									title="CLI Command"
 									value={`nats --server ${installationData?.url} --creds nats.creds stream ls`}


### PR DESCRIPTION
## Summary

Adds a copy & paste one-liner to the **View credentials** dialog (`frontend/src/components/ui/users/user-columns.tsx`) that automatically creates a selected NATS CLI context from a user's credentials on macOS & Linux.

The new **Create NATS CLI context (macOS & Linux)** box generates, per user:

```bash
umask 077 && mkdir -p ~/.config/nats/creds && cat > ~/.config/nats/creds/<account>-<user>.creds <<'NATS_CREDS_EOF'
<creds content>
NATS_CREDS_EOF
nats context save "<account>-<user>" --server "<url>" --creds ~/.config/nats/creds/<account>-<user>.creds --select
```

## Details

- `umask 077` secures the creds file permissions.
- Quoted heredoc delimiter prevents shell expansion of the JWT/seed content.
- `nats context save ... --select` creates and activates the context, so users can immediately run e.g. `nats stream ls` with no extra flags.
- The context/file name is sanitized (`[^a-zA-Z0-9._-]` -> `-`) to stay shell-safe.
- Reuses the existing copy-to-clipboard `CredentialBox` component.

## Testing

- `bun run lint` and `bun run build` (frontend) pass.
- Full E2E integration suite (`integration_tests`): all 5 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the credentials dialog; it formats the same creds already exposed for copy, with no backend or auth logic changes.
> 
> **Overview**
> The **View credentials** dialog now surfaces a copy-paste shell script that writes the user’s creds under `~/.config/nats/creds` and runs `nats context save … --select`, so macOS/Linux users can use the CLI without manual file setup.
> 
> Context names are derived from `account-user` with non-safe characters replaced by `-`. The script uses `umask 077`, a quoted heredoc for the creds body, and the installation server URL from existing operator data. It is shown via a new **Create NATS CLI context (macOS & Linux)** `CredentialBox` above the existing CLI command and creds boxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e444ad36758748c6d5bf5144ce8e228a9b63102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->