### PR TITLE
feat: add admin-only Cluster State page

### DIFF
--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -5,12 +5,14 @@ import {
 	FoldVertical,
 	KeyRound,
 	LayoutDashboard,
+	ServerCog,
 	type LucideIcon,
 } from "lucide-react";
 
 import { NavMain } from "@/components/layout/nav-main";
 import { NavUser } from "@/components/layout/nav-user";
 import { InstallationSwitcher } from "@/components/layout/installation-switcher";
+import { pb } from "@/lib/pocketbase";
 import {
 	Sidebar,
 	SidebarContent,
@@ -65,6 +67,7 @@ export function getNavInfo(resolvedHref: string | undefined) {
 			title: string;
 			url: string;
 			icon: LucideIcon;
+			adminOnly?: boolean;
 			breadcrumb: { name: string; url: string } | undefined;
 			isActive: boolean;
 			subPaths: {
@@ -152,6 +155,18 @@ export function getNavInfo(resolvedHref: string | undefined) {
 				isActive: false,
 				subPaths: [],
 			},
+			{
+				title: "Cluster State",
+				url: "/installations/$installationId/cluster-state",
+				icon: ServerCog,
+				adminOnly: true,
+				breadcrumb: {
+					name: "Cluster State",
+					url: "/installations/$installationId/cluster-state",
+				},
+				isActive: false,
+				subPaths: [],
+			},
 		],
 	};
 
@@ -234,13 +249,18 @@ function compareHrefs(href: string | undefined, resolvedHref: string) {
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const { resolvedLocation } = useRouterState();
 
+	const isAdmin = pb.authStore.isSuperuser;
+	const items = getNavInfo(resolvedLocation?.href).items.filter(
+		(item) => !item.adminOnly || isAdmin,
+	);
+
 	return (
 		<Sidebar collapsible="icon" {...props}>
 			<SidebarHeader>
 				<InstallationSwitcher />
 			</SidebarHeader>
 			<SidebarContent>
-				<NavMain items={getNavInfo(resolvedLocation?.href).items} />
+				<NavMain items={items} />
 			</SidebarContent>
 			<SidebarFooter>
 				<NavUser />

--- a/frontend/src/pages/_app/installations_/$installationId/cluster-state/index.lazy.tsx
+++ b/frontend/src/pages/_app/installations_/$installationId/cluster-state/index.lazy.tsx
@@ -1,0 +1,354 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { RefreshCw, ServerCog } from "lucide-react";
+
+import { pb } from "@/lib/pocketbase";
+import { toStringSigBytesPerKB } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	type ClusterStateJetStreamServer,
+	type ClusterStateStreamAccount,
+	useClusterState,
+} from "@/services/cluster-state";
+
+export const Route = createLazyFileRoute(
+	"/_app/installations_/$installationId/cluster-state/",
+)({
+	component: ClusterState,
+});
+
+function formatBytes(value: number | undefined): string {
+	if (value === undefined) {
+		return "0 B";
+	}
+	return toStringSigBytesPerKB(value, 2, 1024);
+}
+
+function formatNumber(value: number | undefined): string {
+	return (value ?? 0).toLocaleString();
+}
+
+function JetStreamReport({
+	servers,
+}: {
+	servers: ClusterStateJetStreamServer[];
+}) {
+	const totals = servers.reduce(
+		(acc, entry) => {
+			const data = entry.data;
+			if (data && !data.disabled) {
+				acc.streams += data.streams ?? 0;
+				acc.consumers += data.consumers ?? 0;
+				acc.messages += data.messages ?? 0;
+				acc.bytes += data.bytes ?? 0;
+				acc.memory += data.memory ?? 0;
+				acc.storage += data.storage ?? 0;
+				acc.apiReq += data.api?.total ?? 0;
+			}
+			return acc;
+		},
+		{
+			streams: 0,
+			consumers: 0,
+			messages: 0,
+			bytes: 0,
+			memory: 0,
+			storage: 0,
+			apiReq: 0,
+		},
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-lg">JetStream Server Report</CardTitle>
+				<div className="text-sm text-muted-foreground">
+					Output of <code>nats server report jetstream</code> issued within the
+					SYS account.
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="overflow-x-auto">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Server</TableHead>
+								<TableHead>Cluster</TableHead>
+								<TableHead>Domain</TableHead>
+								<TableHead className="text-right">Streams</TableHead>
+								<TableHead className="text-right">Consumers</TableHead>
+								<TableHead className="text-right">Messages</TableHead>
+								<TableHead className="text-right">Bytes</TableHead>
+								<TableHead className="text-right">Memory</TableHead>
+								<TableHead className="text-right">Storage</TableHead>
+								<TableHead className="text-right">API Req</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{servers.map((entry) => {
+								const data = entry.data;
+								const isLeader =
+									data?.meta_cluster?.leader === entry.server.name;
+								return (
+									<TableRow key={entry.server.id}>
+										<TableCell className="font-medium">
+											{entry.server.name}
+											{isLeader ? (
+												<Badge className="ml-2" variant="secondary">
+													meta leader
+												</Badge>
+											) : null}
+										</TableCell>
+										<TableCell>{entry.server.cluster ?? "-"}</TableCell>
+										<TableCell>{entry.server.domain ?? "-"}</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatNumber(data?.streams)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatNumber(data?.consumers)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatNumber(data?.messages)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatBytes(data?.bytes)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatBytes(data?.memory)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatBytes(data?.storage)}
+										</TableCell>
+										<TableCell className="text-right">
+											{data?.disabled ? "-" : formatNumber(data?.api?.total)}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+				</div>
+				<div className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4 lg:grid-cols-7">
+					<TotalStat label="Streams" value={formatNumber(totals.streams)} />
+					<TotalStat label="Consumers" value={formatNumber(totals.consumers)} />
+					<TotalStat label="Messages" value={formatNumber(totals.messages)} />
+					<TotalStat label="Bytes" value={formatBytes(totals.bytes)} />
+					<TotalStat label="Memory" value={formatBytes(totals.memory)} />
+					<TotalStat label="Storage" value={formatBytes(totals.storage)} />
+					<TotalStat label="API Req" value={formatNumber(totals.apiReq)} />
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function TotalStat({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="rounded-lg border bg-muted/30 p-3">
+			<div className="text-xs font-medium text-muted-foreground">{label}</div>
+			<div className="text-base font-semibold">{value}</div>
+		</div>
+	);
+}
+
+function AccountStreamReport({
+	account,
+}: {
+	account: ClusterStateStreamAccount;
+}) {
+	const streamCount = account.streams.length;
+	const totalMessages = account.streams.reduce(
+		(sum, stream) => sum + (stream.state?.messages ?? 0),
+		0,
+	);
+	const totalBytes = account.streams.reduce(
+		(sum, stream) => sum + (stream.state?.bytes ?? 0),
+		0,
+	);
+
+	return (
+		<Collapsible
+			className="rounded-lg border"
+			defaultOpen={streamCount > 0 && streamCount <= 25}
+		>
+			<CollapsibleTrigger className="flex w-full items-center justify-between gap-2 p-4 text-left hover:bg-muted/40">
+				<div className="min-w-0">
+					<div className="truncate font-semibold">{account.account_name}</div>
+					<div className="truncate text-xs text-muted-foreground">
+						{account.account_key}
+					</div>
+				</div>
+				<div className="flex shrink-0 items-center gap-2 text-sm text-muted-foreground">
+					<Badge variant="outline">{streamCount} streams</Badge>
+					<span>{formatNumber(totalMessages)} msgs</span>
+					<span>{formatBytes(totalBytes)}</span>
+				</div>
+			</CollapsibleTrigger>
+			<CollapsibleContent>
+				{streamCount === 0 ? (
+					<div className="p-4 text-sm text-muted-foreground">
+						No streams in this account.
+					</div>
+				) : (
+					<div className="overflow-x-auto border-t">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Stream</TableHead>
+									<TableHead>Storage</TableHead>
+									<TableHead className="text-right">Replicas</TableHead>
+									<TableHead className="text-right">Consumers</TableHead>
+									<TableHead className="text-right">Messages</TableHead>
+									<TableHead className="text-right">Bytes</TableHead>
+									<TableHead>Cluster</TableHead>
+									<TableHead>Leader</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{account.streams.map((stream) => (
+									<TableRow key={stream.name}>
+										<TableCell className="font-medium">{stream.name}</TableCell>
+										<TableCell>{stream.config?.storage ?? "-"}</TableCell>
+										<TableCell className="text-right">
+											{stream.config?.num_replicas ?? 1}
+										</TableCell>
+										<TableCell className="text-right">
+											{formatNumber(stream.state?.consumer_count)}
+										</TableCell>
+										<TableCell className="text-right">
+											{formatNumber(stream.state?.messages)}
+										</TableCell>
+										<TableCell className="text-right">
+											{formatBytes(stream.state?.bytes)}
+										</TableCell>
+										<TableCell>{stream.cluster?.name ?? "-"}</TableCell>
+										<TableCell>{stream.cluster?.leader ?? "-"}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				)}
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
+
+function ClusterState() {
+	const { installationId } = Route.useParams();
+	const isAdmin = pb.authStore.isSuperuser;
+
+	const { data, error, isLoading, isValidating, mutate } =
+		useClusterState(installationId);
+
+	if (!isAdmin) {
+		return (
+			<div className="p-4">
+				<div className="container mx-auto">
+					<h2 className="text-2xl font-bold">Cluster State</h2>
+					<div className="mt-2 text-sm text-muted-foreground">
+						You need admin privileges to view the cluster state.
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="p-4">
+			<div className="container mx-auto">
+				<div className="mb-6 flex flex-row items-center">
+					<div className="flex flex-1 items-center gap-3">
+						<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+							<ServerCog className="size-4" />
+						</span>
+						<div>
+							<h2 className="text-2xl font-bold">Cluster State</h2>
+							<div className="text-sm text-muted-foreground">
+								JetStream and per-account stream diagnostics for this
+								installation.
+							</div>
+						</div>
+					</div>
+					<Button
+						variant="outline"
+						onClick={() => mutate()}
+						disabled={isLoading || isValidating}
+					>
+						<RefreshCw
+							className={isValidating ? "animate-spin" : undefined}
+						/>
+						Refresh
+					</Button>
+				</div>
+			</div>
+
+			<div className="container mx-auto space-y-6">
+				{error ? (
+					<Card>
+						<CardContent className="p-4 text-sm text-destructive">
+							Failed to load cluster state.
+						</CardContent>
+					</Card>
+				) : null}
+
+				{isLoading && !data ? (
+					<Card>
+						<CardContent className="p-4 text-sm text-muted-foreground">
+							Loading cluster state…
+						</CardContent>
+					</Card>
+				) : null}
+
+				{data ? (
+					<>
+						<JetStreamReport servers={data.jetstream} />
+
+						<div className="space-y-2">
+							<div className="flex items-baseline justify-between">
+								<h3 className="text-lg font-semibold">Stream Report</h3>
+								<span className="text-sm text-muted-foreground">
+									{data.accounts.length} accounts
+								</span>
+							</div>
+							<div className="text-sm text-muted-foreground">
+								Output of <code>nats stream report --all</code> issued per
+								account.
+							</div>
+							<div className="space-y-3 pt-2">
+								{data.accounts.length === 0 ? (
+									<Card>
+										<CardContent className="p-4 text-sm text-muted-foreground">
+											No accounts with JetStream streams found.
+										</CardContent>
+									</Card>
+								) : (
+									data.accounts.map((account) => (
+										<AccountStreamReport
+											key={account.account_key}
+											account={account}
+										/>
+									))
+								)}
+							</div>
+						</div>
+					</>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,8 @@ const AppInstallationsIndexLazyRouteImport = createFileRoute(
 )()
 const AppInstallationsInstallationIdLimitsIndexLazyRouteImport =
   createFileRoute('/_app/installations_/$installationId/limits/')()
+const AppInstallationsInstallationIdClusterStateIndexLazyRouteImport =
+  createFileRoute('/_app/installations_/$installationId/cluster-state/')()
 const AppInstallationsInstallationIdAccountsIndexLazyRouteImport =
   createFileRoute('/_app/installations_/$installationId/accounts/')()
 const AppInstallationsInstallationIdAccountsAccountIdUsersIndexLazyRouteImport =
@@ -79,6 +81,16 @@ const AppInstallationsInstallationIdLimitsIndexLazyRoute =
     getParentRoute: () => AppRoute,
   } as any).lazy(() =>
     import('./pages/_app/installations_/$installationId/limits/index.lazy').then(
+      (d) => d.Route,
+    ),
+  )
+const AppInstallationsInstallationIdClusterStateIndexLazyRoute =
+  AppInstallationsInstallationIdClusterStateIndexLazyRouteImport.update({
+    id: '/installations_/$installationId/cluster-state/',
+    path: '/installations/$installationId/cluster-state/',
+    getParentRoute: () => AppRoute,
+  } as any).lazy(() =>
+    import('./pages/_app/installations_/$installationId/cluster-state/index.lazy').then(
       (d) => d.Route,
     ),
   )
@@ -159,6 +171,7 @@ export interface FileRoutesByFullPath {
   '/installations/$installationId': typeof AppInstallationsInstallationIdRoute
   '/installations/': typeof AppInstallationsIndexLazyRoute
   '/installations/$installationId/accounts/': typeof AppInstallationsInstallationIdAccountsIndexLazyRoute
+  '/installations/$installationId/cluster-state/': typeof AppInstallationsInstallationIdClusterStateIndexLazyRoute
   '/installations/$installationId/limits/': typeof AppInstallationsInstallationIdLimitsIndexLazyRoute
   '/installations/$installationId/accounts/$accountId/exports/': typeof AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute
   '/installations/$installationId/accounts/$accountId/imports/': typeof AppInstallationsInstallationIdAccountsAccountIdImportsIndexLazyRoute
@@ -172,6 +185,7 @@ export interface FileRoutesByTo {
   '/installations/$installationId': typeof AppInstallationsInstallationIdRoute
   '/installations': typeof AppInstallationsIndexLazyRoute
   '/installations/$installationId/accounts': typeof AppInstallationsInstallationIdAccountsIndexLazyRoute
+  '/installations/$installationId/cluster-state': typeof AppInstallationsInstallationIdClusterStateIndexLazyRoute
   '/installations/$installationId/limits': typeof AppInstallationsInstallationIdLimitsIndexLazyRoute
   '/installations/$installationId/accounts/$accountId/exports': typeof AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute
   '/installations/$installationId/accounts/$accountId/imports': typeof AppInstallationsInstallationIdAccountsAccountIdImportsIndexLazyRoute
@@ -187,6 +201,7 @@ export interface FileRoutesById {
   '/_app/installations/$installationId': typeof AppInstallationsInstallationIdRoute
   '/_app/installations/': typeof AppInstallationsIndexLazyRoute
   '/_app/installations_/$installationId/accounts/': typeof AppInstallationsInstallationIdAccountsIndexLazyRoute
+  '/_app/installations_/$installationId/cluster-state/': typeof AppInstallationsInstallationIdClusterStateIndexLazyRoute
   '/_app/installations_/$installationId/limits/': typeof AppInstallationsInstallationIdLimitsIndexLazyRoute
   '/_app/installations_/$installationId/accounts_/$accountId/exports/': typeof AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute
   '/_app/installations_/$installationId/accounts_/$accountId/imports/': typeof AppInstallationsInstallationIdAccountsAccountIdImportsIndexLazyRoute
@@ -202,6 +217,7 @@ export interface FileRouteTypes {
     | '/installations/$installationId'
     | '/installations/'
     | '/installations/$installationId/accounts/'
+    | '/installations/$installationId/cluster-state/'
     | '/installations/$installationId/limits/'
     | '/installations/$installationId/accounts/$accountId/exports/'
     | '/installations/$installationId/accounts/$accountId/imports/'
@@ -215,6 +231,7 @@ export interface FileRouteTypes {
     | '/installations/$installationId'
     | '/installations'
     | '/installations/$installationId/accounts'
+    | '/installations/$installationId/cluster-state'
     | '/installations/$installationId/limits'
     | '/installations/$installationId/accounts/$accountId/exports'
     | '/installations/$installationId/accounts/$accountId/imports'
@@ -229,6 +246,7 @@ export interface FileRouteTypes {
     | '/_app/installations/$installationId'
     | '/_app/installations/'
     | '/_app/installations_/$installationId/accounts/'
+    | '/_app/installations_/$installationId/cluster-state/'
     | '/_app/installations_/$installationId/limits/'
     | '/_app/installations_/$installationId/accounts_/$accountId/exports/'
     | '/_app/installations_/$installationId/accounts_/$accountId/imports/'
@@ -286,6 +304,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppInstallationsInstallationIdLimitsIndexLazyRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/installations_/$installationId/cluster-state/': {
+      id: '/_app/installations_/$installationId/cluster-state/'
+      path: '/installations/$installationId/cluster-state'
+      fullPath: '/installations/$installationId/cluster-state/'
+      preLoaderRoute: typeof AppInstallationsInstallationIdClusterStateIndexLazyRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/installations_/$installationId/accounts/': {
       id: '/_app/installations_/$installationId/accounts/'
       path: '/installations/$installationId/accounts'
@@ -336,6 +361,7 @@ interface AppRouteChildren {
   AppInstallationsInstallationIdRoute: typeof AppInstallationsInstallationIdRoute
   AppInstallationsIndexLazyRoute: typeof AppInstallationsIndexLazyRoute
   AppInstallationsInstallationIdAccountsIndexLazyRoute: typeof AppInstallationsInstallationIdAccountsIndexLazyRoute
+  AppInstallationsInstallationIdClusterStateIndexLazyRoute: typeof AppInstallationsInstallationIdClusterStateIndexLazyRoute
   AppInstallationsInstallationIdLimitsIndexLazyRoute: typeof AppInstallationsInstallationIdLimitsIndexLazyRoute
   AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute: typeof AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute
   AppInstallationsInstallationIdAccountsAccountIdImportsIndexLazyRoute: typeof AppInstallationsInstallationIdAccountsAccountIdImportsIndexLazyRoute
@@ -350,6 +376,8 @@ const AppRouteChildren: AppRouteChildren = {
   AppInstallationsIndexLazyRoute: AppInstallationsIndexLazyRoute,
   AppInstallationsInstallationIdAccountsIndexLazyRoute:
     AppInstallationsInstallationIdAccountsIndexLazyRoute,
+  AppInstallationsInstallationIdClusterStateIndexLazyRoute:
+    AppInstallationsInstallationIdClusterStateIndexLazyRoute,
   AppInstallationsInstallationIdLimitsIndexLazyRoute:
     AppInstallationsInstallationIdLimitsIndexLazyRoute,
   AppInstallationsInstallationIdAccountsAccountIdExportsIndexLazyRoute:

--- a/frontend/src/services/cluster-state.tsx
+++ b/frontend/src/services/cluster-state.tsx
@@ -1,0 +1,110 @@
+import { pb } from "@/lib/pocketbase";
+import useSWR from "swr";
+
+export interface ClusterStateServerInfo {
+	name: string;
+	id: string;
+	cluster?: string;
+	domain?: string;
+	ver?: string;
+}
+
+export interface ClusterStateJetStreamApiStats {
+	level?: number;
+	total?: number;
+	errors?: number;
+}
+
+export interface ClusterStateJSInfo {
+	server_id: string;
+	disabled?: boolean;
+	memory: number;
+	storage: number;
+	accounts?: number;
+	ha_assets?: number;
+	api?: ClusterStateJetStreamApiStats;
+	streams: number;
+	consumers: number;
+	messages: number;
+	bytes: number;
+	meta_cluster?: {
+		name?: string;
+		leader?: string;
+		cluster_size?: number;
+	};
+}
+
+export interface ClusterStateJetStreamServer {
+	server: ClusterStateServerInfo;
+	data?: ClusterStateJSInfo;
+}
+
+export interface ClusterStatePeerInfo {
+	name: string;
+	current: boolean;
+	offline?: boolean;
+	active: number;
+	lag?: number;
+	peer: string;
+}
+
+export interface ClusterStateStreamCluster {
+	name?: string;
+	raft_group?: string;
+	leader?: string;
+	replicas?: ClusterStatePeerInfo[];
+}
+
+export interface ClusterStateStreamState {
+	messages: number;
+	bytes: number;
+	first_seq: number;
+	last_seq: number;
+	num_subjects?: number;
+	num_deleted?: number;
+	consumer_count: number;
+}
+
+export interface ClusterStateStreamConfig {
+	name: string;
+	storage?: string;
+	num_replicas?: number;
+	retention?: string;
+}
+
+export interface ClusterStateStreamDetail {
+	name: string;
+	created?: string;
+	cluster?: ClusterStateStreamCluster;
+	config?: ClusterStateStreamConfig;
+	state?: ClusterStateStreamState;
+}
+
+export interface ClusterStateStreamAccount {
+	account_id: string;
+	account_key: string;
+	account_name: string;
+	streams: ClusterStateStreamDetail[];
+}
+
+export interface ClusterState {
+	jetstream: ClusterStateJetStreamServer[];
+	accounts: ClusterStateStreamAccount[];
+}
+
+export function useClusterState(installationId: string) {
+	return useSWR(
+		[`/installations/${installationId}/cluster_state`, installationId],
+		async ([_, pInstallationId]) => {
+			if (!pInstallationId) {
+				return;
+			}
+			return pb.send<ClusterState>(
+				`/api/nats-tower/installations/${pInstallationId}/cluster_state`,
+				{
+					method: "GET",
+				},
+			);
+		},
+	);
+}

--- a/interfaces/restapi/cluster_state_handler.go
+++ b/interfaces/restapi/cluster_state_handler.go
@@ -1,0 +1,205 @@
+package restapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+
+	"github.com/nats-tower/nats-tower/interfaces/restapi/utils"
+	"github.com/nats-tower/nats-tower/natsauth"
+)
+
+// clusterStateStreamAccount groups the streams of a single account, mirroring
+// the per-account output of `nats stream report --all`.
+type clusterStateStreamAccount struct {
+	AccountID   string                `json:"account_id"`
+	AccountKey  string                `json:"account_key"`
+	AccountName string                `json:"account_name"`
+	Streams     []server.StreamDetail `json:"streams"`
+}
+
+// clusterStateResponse contains the combined output of
+// `nats server report jetstream` (per-server JetStream info) and
+// `nats stream report --all` (streams grouped per account).
+type clusterStateResponse struct {
+	JetStream []*server.ServerAPIJszResponse `json:"jetstream"`
+	Accounts  []clusterStateStreamAccount    `json:"accounts"`
+}
+
+// GetClusterState returns cluster-wide JetStream diagnostics. It is restricted
+// to superusers because it exposes information across every account.
+func GetClusterState(e *core.RequestEvent, installationID string) error {
+	if installationID == "" {
+		return e.Error(http.StatusBadRequest, "installation_id is required", nil)
+	}
+
+	if !e.HasSuperuserAuth() {
+		return e.Error(http.StatusForbidden, "Only admins can access the cluster state", nil)
+	}
+
+	natsauthModule := utils.MustGetNATSAuth(e)
+	ctx := e.Request.Context()
+
+	sysUserAuth, err := natsauthModule.GetSysUserByID(ctx, installationID)
+	if err != nil {
+		return e.Error(http.StatusInternalServerError, "Failed to get sys user", err)
+	}
+
+	nc, err := nats.Connect(sysUserAuth.URL, nats.UserJWTAndSeed(sysUserAuth.JWT, sysUserAuth.Seed))
+	if err != nil {
+		return e.Error(http.StatusInternalServerError, "Failed to connect to NATS", err)
+	}
+	defer nc.Close()
+
+	clusterInfo, err := getClusterInfoWithConnection(ctx, natsauthModule, nc)
+	if err != nil {
+		return e.Error(http.StatusInternalServerError, "Failed to get cluster info", err)
+	}
+
+	activeServers := -1
+	if len(clusterInfo) > 0 {
+		activeServers = clusterInfo[0].Stats.ActiveServers
+	}
+
+	// Resolve account public keys to the tower account names/ids.
+	accountByKey := map[string]*core.Record{}
+	accountRecords, err := e.App.FindAllRecords("nats_auth_accounts",
+		dbx.HashExp{"operator": installationID})
+	if err != nil {
+		return e.Error(http.StatusInternalServerError, "Failed to list accounts", err)
+	}
+	for _, record := range accountRecords {
+		accountByKey[record.GetString("public_key")] = record
+	}
+
+	// A single JSZ ping (issued from the SYS account/user) yields both the
+	// per-server JetStream report and the per-account stream details.
+	jszResponses := []*server.ServerAPIJszResponse{}
+	// account key -> stream name -> detail (deduplicated across replicas).
+	streamsByAccount := map[string]map[string]server.StreamDetail{}
+	accountKeyOrder := []string{}
+
+	_, err = natsauth.RequestMultiple(ctx, nc,
+		"$SYS.REQ.SERVER.PING.JSZ",
+		[]byte(`{"accounts":true,"streams":true}`),
+		natsauth.RequestMultipleOptions{
+			MaxResponses: activeServers,
+			Timeout:      5 * time.Second,
+			EachFunc: func(m *nats.Msg) bool {
+				resp := &server.ServerAPIJszResponse{}
+				if jsonErr := json.Unmarshal(m.Data, resp); jsonErr != nil {
+					return true
+				}
+
+				serverName := ""
+				if resp.Server != nil {
+					serverName = resp.Server.Name
+				}
+
+				if resp.Data != nil {
+					for _, accountDetail := range resp.Data.AccountDetails {
+						mergeAccountStreams(streamsByAccount, &accountKeyOrder, serverName, accountDetail)
+					}
+					// Account details are returned separately, so drop them from
+					// the server report to keep the payload small.
+					resp.Data.AccountDetails = nil
+				}
+
+				jszResponses = append(jszResponses, resp)
+				return true
+			},
+		})
+	if err != nil {
+		return e.Error(http.StatusInternalServerError, "Failed to get JetStream report", err)
+	}
+
+	sort.Slice(jszResponses, func(i, j int) bool {
+		return jszServerName(jszResponses[i]) < jszServerName(jszResponses[j])
+	})
+
+	accounts := make([]clusterStateStreamAccount, 0, len(accountKeyOrder))
+	for _, accountKey := range accountKeyOrder {
+		streamMap := streamsByAccount[accountKey]
+
+		streams := make([]server.StreamDetail, 0, len(streamMap))
+		for _, stream := range streamMap {
+			streams = append(streams, stream)
+		}
+		sort.Slice(streams, func(i, j int) bool {
+			return streams[i].Name < streams[j].Name
+		})
+
+		entry := clusterStateStreamAccount{
+			AccountKey: accountKey,
+			Streams:    streams,
+		}
+		if record, ok := accountByKey[accountKey]; ok {
+			entry.AccountID = record.Id
+			entry.AccountName = record.GetString("name")
+		}
+		if entry.AccountName == "" {
+			entry.AccountName = accountKey
+		}
+		accounts = append(accounts, entry)
+	}
+
+	sort.Slice(accounts, func(i, j int) bool {
+		return accounts[i].AccountName < accounts[j].AccountName
+	})
+
+	return e.JSON(http.StatusOK, &clusterStateResponse{
+		JetStream: jszResponses,
+		Accounts:  accounts,
+	})
+}
+
+// mergeAccountStreams collects the streams for an account across all servers,
+// deduplicating by stream name and preferring the copy reported by the stream's
+// leader (which holds the authoritative state).
+func mergeAccountStreams(streamsByAccount map[string]map[string]server.StreamDetail,
+	accountKeyOrder *[]string,
+	serverName string,
+	accountDetail *server.AccountDetail) {
+
+	if accountDetail == nil {
+		return
+	}
+
+	accountKey := accountDetail.Id
+	if accountKey == "" {
+		accountKey = accountDetail.Name
+	}
+
+	streamMap, ok := streamsByAccount[accountKey]
+	if !ok {
+		streamMap = map[string]server.StreamDetail{}
+		streamsByAccount[accountKey] = streamMap
+		*accountKeyOrder = append(*accountKeyOrder, accountKey)
+	}
+
+	for _, stream := range accountDetail.Streams {
+		_, exists := streamMap[stream.Name]
+		// Prefer the copy produced by the stream's own leader (authoritative
+		// state); otherwise keep the first copy seen.
+		if !exists || streamReportedByLeader(stream, serverName) {
+			streamMap[stream.Name] = stream
+		}
+	}
+}
+
+func streamReportedByLeader(stream server.StreamDetail, serverName string) bool {
+	return stream.Cluster != nil && stream.Cluster.Leader == serverName
+}
+
+func jszServerName(resp *server.ServerAPIJszResponse) string {
+	if resp.Server == nil {
+		return ""
+	}
+	return resp.Server.Name
+}

--- a/interfaces/restapi/routes.go
+++ b/interfaces/restapi/routes.go
@@ -119,6 +119,12 @@ func RegisterAPIRoutes(ctx context.Context,
 			return e.JSON(http.StatusOK, clusterInfo)
 		}).BindFunc(metricsMiddleware.WrapHandler("/api/nats-tower/installations/:installation_id/cluster_info"))
 
+	installationGroup.GET("/cluster_state",
+		func(e *core.RequestEvent) error {
+			installationID := e.Request.PathValue("installation_id")
+			return GetClusterState(e, installationID)
+		}).BindFunc(metricsMiddleware.WrapHandler("/api/nats-tower/installations/:installation_id/cluster_state"))
+
 	accountGroup := installationGroup.Group("/accounts/{account_id}")
 	accountGroup.BindFunc(func(e *core.RequestEvent) error {
 		requestInfo, err := e.RequestInfo()


### PR DESCRIPTION
## Summary

Adds a new **Cluster State** navigation entry and page, visible only to logged-in admins (superusers). It surfaces cluster-wide JetStream diagnostics for an installation, equivalent to two `nats` CLI commands:

- **`nats server report jetstream`** — per-server JetStream info, issued from the SYS account `sys` user.
- **`nats stream report --all`** — streams grouped per account.

Both reports are derived from a single cluster-wide `$SYS.REQ.SERVER.PING.JSZ` request (`{"accounts":true,"streams":true}`) to avoid one round-trip per account.

## Changes

### Backend
- `interfaces/restapi/cluster_state_handler.go`: new `GetClusterState` handler, restricted to superusers via `e.HasSuperuserAuth()`. Connects as the SYS `sys` user, collects per-server JetStream info and per-account stream details (deduplicated across replicas, preferring the leader's authoritative copy), and maps account public keys to Tower account names/ids.
- `interfaces/restapi/routes.go`: registers `GET /api/nats-tower/installations/{installation_id}/cluster_state`.

### Frontend
- `components/layout/app-sidebar.tsx`: adds an admin-only `Cluster State` nav item (`ServerCog` icon); `AppSidebar` filters admin-only items using `pb.authStore.isSuperuser`.
- `services/cluster-state.tsx`: SWR hook + typed response.
- `pages/_app/installations_/$installationId/cluster-state/index.lazy.tsx`: the page — a JetStream server-report table with totals, plus a collapsible per-account stream report. Non-admins see an access message.

## Testing
- `go build ./...` and `go vet ./interfaces/...` pass.
- Frontend `bun run build` (type-check + regenerated route tree) and `bun run lint` pass.
- E2E suite (`integration_tests/`): all 5 scenarios pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New superuser-gated API exposes cross-account JetStream/stream metadata via SYS credentials; enforcement relies on backend auth, with UI-only hiding for non-admins.
> 
> **Overview**
> Introduces **Cluster State** diagnostics for an installation, aimed at admins who need cluster-wide JetStream visibility comparable to `nats server report jetstream` and `nats stream report --all`.
> 
> The backend adds `GET .../cluster_state`, gated with `HasSuperuserAuth()`. It connects as the SYS user, issues one `$SYS.REQ.SERVER.PING.JSZ` with accounts and streams enabled, returns per-server JetStream stats (with account details stripped from that payload), and builds per-account stream lists with deduplication that prefers the stream leader’s copy. Account public keys are mapped to Tower account names/ids.
> 
> The frontend adds an **admin-only** sidebar item (`adminOnly` + `pb.authStore.isSuperuser` filter), a lazy route, an SWR hook, and a page with a JetStream server table (totals + meta leader badge), collapsible per-account stream tables, refresh, and a client-side access message for non-admins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec4e8a43d92dbed4d93ca435e8f6b812b501e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->