### PR TITLE
fix(frontend): interpret server cpu stat as percentage not core count

### DIFF
--- a/frontend/src/components/ui/cluster-info.tsx
+++ b/frontend/src/components/ui/cluster-info.tsx
@@ -35,10 +35,12 @@ interface ServerInfo {
 	statsz: ServerStats;
 }
 
+// statsz.cpu is a percentage where 100% equals one fully used core, so divide
+// by 100 to convert it into a number of cores.
 function calculateTotalUsedCores(serverInfos: ServerInfo[]): number {
 	let total = 0;
 	for (const server of serverInfos) {
-		total += server.statsz.cpu;
+		total += server.statsz.cpu / 100;
 	}
 	return total;
 }
@@ -282,7 +284,7 @@ export function ClusterInfo({ installationId }: ClusterInfoProps) {
 											Used Cores
 										</dt>
 										<dd className="font-medium tabular-nums">
-											{`${server.statsz.cpu.toFixed(2)} / ${server.statsz.cores}`}
+											{`${(server.statsz.cpu / 100).toFixed(2)} / ${server.statsz.cores}`}
 										</dd>
 									</div>
 									<div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Problem

The cluster dashboard's "Used Cores" / "Used Total Cores" stats were wrong. A server using ~11 cores displayed as `1153.00 / 48`, and the total utilization bar rendered fully red because the summed value (e.g. `1196`) exceeded the total core count (`304`).

## Root cause

The dashboard reads `statsz.cpu` from each server (collected via `$SYS.REQ.SERVER.PING` in `getClusterInfoWithConnection`) and treated it as a **number of cores**. However, NATS reports `ServerStats.CPU` as a **CPU usage percentage** where `100%` equals one fully used core (filled by `pse.ProcUsage`, the same metric as `ps pcpu`). On multi-core machines it can range from `0` to `cores × 100`. The `cores` field is separate (`runtime.NumCPU()`).

So the UI was summing percentages and comparing them against core counts.

## Fix

Divide `statsz.cpu` by `100` to convert it to a number of cores, for both the per-server "Used Cores" value and the aggregate "Used Total Cores". The utilization bars are now correct since they already divide used cores by total cores.

After the fix, `nuts001` reads `11.53 / 48` and the aggregate reads roughly `11.96 / 304`.

## Testing

- `bun run lint` and `bun run build` pass
- Full E2E integration suite passes (5/5 scenarios)